### PR TITLE
Require net and tls as before

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,16 +1,7 @@
 'use strict';
-/**
- * expecting NET & TLS to be injected from outside:
- * for RN it should be in shim.js:
- *     global.net = require('react-native-tcp');
- *     global.tls = require('react-native-tcp/tls');
- *
- * for nodejs tests it should be provided before tests:
- *     global.net = require('net');
- *     global.tls = require('tls');
- * */
-let net = global.net;
-let tls = global.tls;
+const net = require('net');
+const tls = require('tls');
+
 const TIMEOUT = 5000;
 
 const TlsSocketWrapper = require('./TlsSocketWrapper.js');


### PR DESCRIPTION
Go back to `require`ing the `net` and `tls` pacakges and let `rn-nodeify` point to the correct versions 