### PR TITLE
Require net and tls as before

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 const Client = require('./lib/client');
 
 class ElectrumClient extends Client {
-  constructor(net, tls, port, host, protocol, options) {
-    super(net, tls, port, host, protocol, options);
+  constructor(port, host, protocol, options) {
+    super(port, host, protocol, options);
     this.timeLastCall = 0;
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,14 +1,7 @@
 'use strict';
-/**
- * NET & TLS dependencies should be injected via constructor
- * for RN it can be something like this in shim.js:
- *     global.net = require('react-native-tcp');
- *     global.tls = require('react-native-tcp/tls');
- *
- * for nodejs tests it should be regular node's net * tls:
- *     const net = require('net');
- *     const tls = require('tls');
- * */
+const net = require('net');
+const tls = require('tls');
+
 const TIMEOUT = 5000;
 
 const TlsSocketWrapper = require('./TlsSocketWrapper.js');
@@ -16,9 +9,7 @@ const EventEmitter = require('events').EventEmitter;
 const util = require('./util');
 
 class Client {
-  constructor(net, tls, port, host, protocol, options) {
-    this.net = net;
-    this.tls = tls;
+  constructor(port, host, protocol, options) {
     this.id = 0;
     this.port = port;
     this.host = host;
@@ -37,14 +28,14 @@ class Client {
     options = options || this._options;
     switch (protocol) {
       case 'tcp':
-        this.conn = new this.net.Socket();
+        this.conn = new net.Socket();
         break;
       case 'tls':
       case 'ssl':
-        if (!this.tls) {
+        if (!tls) {
           throw new Error('tls package could not be loaded');
         }
-        this.conn = new TlsSocketWrapper(this.tls);
+        this.conn = new TlsSocketWrapper(tls);
         break;
       default:
         throw new Error('unknown protocol');


### PR DESCRIPTION
Go back to `require`ing the `net` and `tls` packages and let `rn-nodeify` point to the correct versions when using ReactNative